### PR TITLE
add endpoint to mapping

### DIFF
--- a/src/msg_mapper.py
+++ b/src/msg_mapper.py
@@ -20,18 +20,21 @@ def map_final(msg):
     }
 
 def _convert_msg(msg):
-    # print(json.dumps(msg, indent=2))
     event = msg['Body']['Message']['event']
     eventName = event.get('UserEvent', event['Event'])
     # Use the timestamp from the message body, fall back to the sqs body
     bodyTimestamp = msg['Body']['Timestamp']
     timestamp = msg['Body']['Message'].get('timestamp', bodyTimestamp)
+    channel = event.get('Channel', '')
+    # Current messages should have endpoint, but older ones don't.
+    endpoint = event.get('endpoint', channel)
     return {
         'id': msg['MessageId'],
         'receipt_handle': msg['ReceiptHandle'],
         'timestamp': timestamp,
         'hostname': msg['Body']['Message']['hostname'],
-        'channel': event.get('Channel', ''),
+        'channel': channel,
+        'endpoint': endpoint,
         'event': eventName
     }
 

--- a/src/test/testtest.py
+++ b/src/test/testtest.py
@@ -1,6 +1,7 @@
 from unittest import mock, TestCase
 
 import msg_mapper
+import sqs_buffer
 
 msg_asterisk = {'ReceiptHandle': 'xxx', 'MessageId': 'xxx', 'Body': {'Timestamp': 'xxx', 'Message': {"timestamp": "2023-07-26T19:48:18+00:00", "hostname": "futel-prod.phu73l.net", "event": {"Event": "UserEvent", "Privilege": "user,all", "Channel": "PJSIP/twilio-000012b0", "ChannelState": "6", "ChannelStateDesc": "Up", "CallerIDNum": "+15034448615", "CallerIDName": "ghost-mountain", "ConnectedLineNum": "<unknown>", "ConnectedLineName": "<unknown>", "Language": "en", "AccountCode": "", "Context": "robotron_ninth_position_play", "Exten": "i", "Priority": "1", "Uniqueid": "1690400891.5412", "Linkedid": "1690400891.5412", "UserEvent": "robotron_ninth_position_play"}}}}
 
@@ -8,14 +9,17 @@ msg_do = {'ReceiptHandle': 'xxx', 'MessageId': 'xxx', 'Body': {'Timestamp': 'xxx
 
 class TestTest(TestCase):
 
-    def test_test(self):
+    def test_convet_msg(self):
         self.assertEqual(
             msg_mapper._convert_msg(msg_asterisk),
             {'id': 'xxx', 'receipt_handle': 'xxx', 'timestamp': '2023-07-26T19:48:18+00:00', 'hostname': 'futel-prod.phu73l.net', 'channel': 'PJSIP/twilio-000012b0', 'event': 'robotron_ninth_position_play'})
         self.assertEqual(
             msg_mapper._convert_msg(msg_do),
             {'id': 'xxx', 'receipt_handle': 'xxx', 'timestamp': '2023-07-26T19:49:18.695810', 'hostname': 'do-functions-prod', 'channel': 'ghost-mountain', 'event': 'outgoing_dialstatus_completed_ghost-mountain'})
-        #context = mock.Mock()
+
+    def test_is_useful(self):
+        self.assertTrue(
+            sqs_buffer.is_useful(msg_mapper._convert_msg(msg_asterisk)))
 
 
 if __name__ == '__main__':

--- a/src/test/testtest.py
+++ b/src/test/testtest.py
@@ -9,13 +9,23 @@ msg_do = {'ReceiptHandle': 'xxx', 'MessageId': 'xxx', 'Body': {'Timestamp': 'xxx
 
 class TestTest(TestCase):
 
-    def test_convet_msg(self):
+    def test_convert_msg(self):
         self.assertEqual(
             msg_mapper._convert_msg(msg_asterisk),
-            {'id': 'xxx', 'receipt_handle': 'xxx', 'timestamp': '2023-07-26T19:48:18+00:00', 'hostname': 'futel-prod.phu73l.net', 'channel': 'PJSIP/twilio-000012b0', 'event': 'robotron_ninth_position_play'})
+            {'id': 'xxx',
+             'receipt_handle': 'xxx',
+             'timestamp': '2023-07-26T19:48:18+00:00',
+             'hostname': 'futel-prod.phu73l.net',
+             'channel': 'PJSIP/twilio-000012b0',
+             'event': 'robotron_ninth_position_play'})
         self.assertEqual(
             msg_mapper._convert_msg(msg_do),
-            {'id': 'xxx', 'receipt_handle': 'xxx', 'timestamp': '2023-07-26T19:49:18.695810', 'hostname': 'do-functions-prod', 'channel': 'ghost-mountain', 'event': 'outgoing_dialstatus_completed_ghost-mountain'})
+            {'id': 'xxx',
+             'receipt_handle': 'xxx',
+             'timestamp': '2023-07-26T19:49:18.695810',
+             'hostname': 'do-functions-prod',
+             'channel': 'ghost-mountain',
+             'event': 'outgoing_dialstatus_completed_ghost-mountain'})
 
     def test_is_useful(self):
         self.assertTrue(

--- a/src/test/testtest.py
+++ b/src/test/testtest.py
@@ -1,0 +1,22 @@
+from unittest import mock, TestCase
+
+import msg_mapper
+
+msg_asterisk = {'ReceiptHandle': 'xxx', 'MessageId': 'xxx', 'Body': {'Timestamp': 'xxx', 'Message': {"timestamp": "2023-07-26T19:48:18+00:00", "hostname": "futel-prod.phu73l.net", "event": {"Event": "UserEvent", "Privilege": "user,all", "Channel": "PJSIP/twilio-000012b0", "ChannelState": "6", "ChannelStateDesc": "Up", "CallerIDNum": "+15034448615", "CallerIDName": "ghost-mountain", "ConnectedLineNum": "<unknown>", "ConnectedLineName": "<unknown>", "Language": "en", "AccountCode": "", "Context": "robotron_ninth_position_play", "Exten": "i", "Priority": "1", "Uniqueid": "1690400891.5412", "Linkedid": "1690400891.5412", "UserEvent": "robotron_ninth_position_play"}}}}
+
+msg_do = {'ReceiptHandle': 'xxx', 'MessageId': 'xxx', 'Body': {'Timestamp': 'xxx', 'Message': {"timestamp": "2023-07-26T19:49:18.695810", "hostname": "do-functions-prod", "event": {"Event": "UserEvent", "endpoint": "ghost-mountain", "Channel": "ghost-mountain", "UserEvent": "outgoing_dialstatus_completed_ghost-mountain"}}}}
+
+class TestTest(TestCase):
+
+    def test_test(self):
+        self.assertEqual(
+            msg_mapper._convert_msg(msg_asterisk),
+            {'id': 'xxx', 'receipt_handle': 'xxx', 'timestamp': '2023-07-26T19:48:18+00:00', 'hostname': 'futel-prod.phu73l.net', 'channel': 'PJSIP/twilio-000012b0', 'event': 'robotron_ninth_position_play'})
+        self.assertEqual(
+            msg_mapper._convert_msg(msg_do),
+            {'id': 'xxx', 'receipt_handle': 'xxx', 'timestamp': '2023-07-26T19:49:18.695810', 'hostname': 'do-functions-prod', 'channel': 'ghost-mountain', 'event': 'outgoing_dialstatus_completed_ghost-mountain'})
+        #context = mock.Mock()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test/testtest.py
+++ b/src/test/testtest.py
@@ -17,6 +17,7 @@ class TestTest(TestCase):
              'timestamp': '2023-07-26T19:48:18+00:00',
              'hostname': 'futel-prod.phu73l.net',
              'channel': 'PJSIP/twilio-000012b0',
+             'endpoint': 'PJSIP/twilio-000012b0',
              'event': 'robotron_ninth_position_play'})
         self.assertEqual(
             msg_mapper._convert_msg(msg_do),
@@ -25,6 +26,7 @@ class TestTest(TestCase):
              'timestamp': '2023-07-26T19:49:18.695810',
              'hostname': 'do-functions-prod',
              'channel': 'ghost-mountain',
+             'endpoint': 'ghost-mountain',
              'event': 'outgoing_dialstatus_completed_ghost-mountain'})
 
     def test_is_useful(self):


### PR DESCRIPTION
Consolidating all new upstream messages to use 'endpoint' instead of implementation-specific 'channel' etc. Asterisk and other sources all have endpoint as of today, the frontend doesn't use it yet.