### PR TITLE
add update representation returned by map_final to munge in endpoint

### DIFF
--- a/src/msg_mapper.py
+++ b/src/msg_mapper.py
@@ -15,7 +15,7 @@ def map_messages(msgs):
 def map_final(msg):
     return {
         'timestamp': msg['timestamp'],
-        'channel': msg['channel'],
+        'channel': msg['endpoint'],
         'event': msg['event']
     }
 

--- a/src/msg_mapper.py
+++ b/src/msg_mapper.py
@@ -15,7 +15,8 @@ def map_messages(msgs):
 def map_final(msg):
     return {
         'timestamp': msg['timestamp'],
-        'channel': msg['endpoint'],
+        'channel': msg['channel'],
+        'endpoint': msg['endpoint'],
         'event': msg['event']
     }
 


### PR DESCRIPTION
untested

I didn't want to add an new attr and keep the old because the contents of channel have changed with implementation over the years and we need to use regexps to read them anyway.

https://github.com/futel/usage/issues/69
